### PR TITLE
Cycle CS pin in case of checksum error

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -942,6 +942,7 @@ where
 
         let pec = PEC15::calc(&result[0..6]);
         if pec[0] != result[6] || pec[1] != result[7] {
+            self.cs.set_high().map_err(Error::CSPinError)?;
             return Err(Error::ChecksumMismatch);
         }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -974,13 +974,13 @@ where
         }
 
         // Constant of 276 °C, which needs to be subtracted
-        const TEMP_SUB: i16 = 20976;
+        const TEMP_SUB: i32 = 20976;
 
         // Check if temperature is negative
-        let temp_i32: i16 = if value >= TEMP_SUB as u16 {
-            value as i16 - TEMP_SUB
+        let temp_i32: i32 = if value >= TEMP_SUB as u16 {
+            value as i32 - TEMP_SUB
         } else {
-            0 - TEMP_SUB + value as i16
+            0 - TEMP_SUB + value as i32
         };
 
         // Applying factor 100 uV/7.6 mV


### PR DESCRIPTION
With this PR, I’m adding a line which disables the CS pin in case of a checksum error.
Sometimes it happens that a slave gets in a state which never exits a loop of checksum errors, and a chip select cycle is needed.

With this fix, my firmware never gets stuck in that kind of loop. I don’t know whether this solution applies universally, so I’d like to have my change reviewed, as I am still relatively new to this BMS chip (LTC6813).

I also don’t know if state changes of the CS pin should happen in this function, as callers might not expect this.