### PR TITLE
Fix failing build for no_alloc targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 
+#[cfg(test)]
 extern crate alloc;
 
 pub mod config;


### PR DESCRIPTION
As addressed in #6 build is failing for no_alloc environments. Alloc is only required for unit tests and not for regular prod. builds.