### PR TITLE
Heapless version 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/ltc681x"
 
 [dependencies]
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
-heapless = "0.7.10"
+heapless = "0.8.0"
 fixed = "1.15.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@
 
 extern crate alloc;
 
+pub use heapless;
+
 pub mod config;
 #[cfg(feature = "example")]
 pub mod example;


### PR DESCRIPTION
Updated heapless to version 0.8.0 + added re-export as heapless is part of the public API