### PR TITLE
Fix cell mappings and device specific parameters

### DIFF
--- a/src/ltc6810.rs
+++ b/src/ltc6810.rs
@@ -91,6 +91,10 @@ impl DeviceTypes for LTC6810 {
 
     const REG_CONF_A: Self::Register = Register::Configuration;
     const REG_CONF_B: Option<Self::Register> = None;
+
+    const TOTAL_VOLTAGE_FACTOR: u32 = 10;
+    const INTERNAL_TEMP_GAIN: i32 = 7600;
+    const INTERNAL_TEMP_OFFSET: i16 = 273;
 }
 
 impl<B, const L: usize> LTC681X<B, NoPolling, LTC6810, L>

--- a/src/ltc6811.rs
+++ b/src/ltc6811.rs
@@ -106,6 +106,10 @@ impl DeviceTypes for LTC6811 {
 
     const REG_CONF_A: Self::Register = Register::ConfigurationA;
     const REG_CONF_B: Option<Self::Register> = Some(Register::ConfigurationB);
+
+    const TOTAL_VOLTAGE_FACTOR: u32 = 20;
+    const INTERNAL_TEMP_GAIN: i32 = 7500;
+    const INTERNAL_TEMP_OFFSET: i16 = 273;
 }
 
 impl<B, const L: usize> LTC681X<B, NoPolling, LTC6811, L>
@@ -276,7 +280,25 @@ impl RegisterAddress<LTC6811> {
     }
 }
 
+/// Cell register locations ordered by Channel.
 const CELL_REGISTER_LOCATIONS: [RegisterAddress<LTC6811>; 12] = [
+    RegisterAddress::ltc6811(Channel::Cell1, Register::CellVoltageA, 0),
+    RegisterAddress::ltc6811(Channel::Cell2, Register::CellVoltageA, 1),
+    RegisterAddress::ltc6811(Channel::Cell3, Register::CellVoltageA, 2),
+    RegisterAddress::ltc6811(Channel::Cell4, Register::CellVoltageB, 0),
+    RegisterAddress::ltc6811(Channel::Cell5, Register::CellVoltageB, 1),
+    RegisterAddress::ltc6811(Channel::Cell6, Register::CellVoltageB, 2),
+    RegisterAddress::ltc6811(Channel::Cell7, Register::CellVoltageC, 0),
+    RegisterAddress::ltc6811(Channel::Cell8, Register::CellVoltageC, 1),
+    RegisterAddress::ltc6811(Channel::Cell9, Register::CellVoltageC, 2),
+    RegisterAddress::ltc6811(Channel::Cell10, Register::CellVoltageD, 0),
+    RegisterAddress::ltc6811(Channel::Cell11, Register::CellVoltageD, 1),
+    RegisterAddress::ltc6811(Channel::Cell12, Register::CellVoltageD, 2),
+];
+
+/// Cell register locations ordered by CellSelection. These definitions
+/// should match CELL_REGISTER_LOCATIONS.
+const CELL_REGISTER_LOCATIONS_BY_PAIRS: [RegisterAddress<LTC6811>; 12] = [
     RegisterAddress::ltc6811(Channel::Cell1, Register::CellVoltageA, 0),
     RegisterAddress::ltc6811(Channel::Cell7, Register::CellVoltageC, 0),
     RegisterAddress::ltc6811(Channel::Cell2, Register::CellVoltageA, 1),
@@ -295,12 +317,12 @@ impl RegisterLocator<LTC6811> for CellSelection {
     fn get_locations(&self) -> Iter<'static, RegisterAddress<LTC6811>> {
         match self {
             CellSelection::All => CELL_REGISTER_LOCATIONS.iter(),
-            CellSelection::Pair1 => CELL_REGISTER_LOCATIONS[0..2].iter(),
-            CellSelection::Pair2 => CELL_REGISTER_LOCATIONS[2..4].iter(),
-            CellSelection::Pair3 => CELL_REGISTER_LOCATIONS[4..6].iter(),
-            CellSelection::Pair4 => CELL_REGISTER_LOCATIONS[6..8].iter(),
-            CellSelection::Pair5 => CELL_REGISTER_LOCATIONS[8..10].iter(),
-            CellSelection::Pair6 => CELL_REGISTER_LOCATIONS[10..12].iter(),
+            CellSelection::Pair1 => CELL_REGISTER_LOCATIONS_BY_PAIRS[0..2].iter(),
+            CellSelection::Pair2 => CELL_REGISTER_LOCATIONS_BY_PAIRS[2..4].iter(),
+            CellSelection::Pair3 => CELL_REGISTER_LOCATIONS_BY_PAIRS[4..6].iter(),
+            CellSelection::Pair4 => CELL_REGISTER_LOCATIONS_BY_PAIRS[6..8].iter(),
+            CellSelection::Pair5 => CELL_REGISTER_LOCATIONS_BY_PAIRS[8..10].iter(),
+            CellSelection::Pair6 => CELL_REGISTER_LOCATIONS_BY_PAIRS[10..12].iter(),
         }
     }
 }

--- a/src/ltc6812.rs
+++ b/src/ltc6812.rs
@@ -121,6 +121,10 @@ impl DeviceTypes for LTC6812 {
 
     const REG_CONF_A: Self::Register = Register::ConfigurationA;
     const REG_CONF_B: Option<Self::Register> = Some(Register::ConfigurationB);
+
+    const TOTAL_VOLTAGE_FACTOR: u32 = 30;
+    const INTERNAL_TEMP_GAIN: i32 = 7600;
+    const INTERNAL_TEMP_OFFSET: i16 = 276;
 }
 
 impl<B, const L: usize> LTC681X<B, NoPolling, LTC6812, L>
@@ -309,7 +313,28 @@ impl RegisterAddress<LTC6812> {
     }
 }
 
+/// Cell register locations ordered by Channel.
 const CELL_REGISTER_LOCATIONS: [RegisterAddress<LTC6812>; 15] = [
+    RegisterAddress::ltc6812(Channel::Cell1, Register::CellVoltageA, 0),
+    RegisterAddress::ltc6812(Channel::Cell2, Register::CellVoltageA, 1),
+    RegisterAddress::ltc6812(Channel::Cell3, Register::CellVoltageA, 2),
+    RegisterAddress::ltc6812(Channel::Cell4, Register::CellVoltageB, 0),
+    RegisterAddress::ltc6812(Channel::Cell5, Register::CellVoltageB, 1),
+    RegisterAddress::ltc6812(Channel::Cell6, Register::CellVoltageB, 2),
+    RegisterAddress::ltc6812(Channel::Cell7, Register::CellVoltageC, 0),
+    RegisterAddress::ltc6812(Channel::Cell8, Register::CellVoltageC, 1),
+    RegisterAddress::ltc6812(Channel::Cell9, Register::CellVoltageC, 2),
+    RegisterAddress::ltc6812(Channel::Cell10, Register::CellVoltageD, 0),
+    RegisterAddress::ltc6812(Channel::Cell11, Register::CellVoltageD, 1),
+    RegisterAddress::ltc6812(Channel::Cell12, Register::CellVoltageD, 2),
+    RegisterAddress::ltc6812(Channel::Cell13, Register::CellVoltageE, 0),
+    RegisterAddress::ltc6812(Channel::Cell14, Register::CellVoltageE, 1),
+    RegisterAddress::ltc6812(Channel::Cell15, Register::CellVoltageE, 2),
+];
+
+/// Cell register locations ordered by CellSelection. These definitions
+/// should match CELL_REGISTER_LOCATIONS.
+const CELL_REGISTER_LOCATIONS_BY_PAIRS: [RegisterAddress<LTC6812>; 15] = [
     RegisterAddress::ltc6812(Channel::Cell1, Register::CellVoltageA, 0),
     RegisterAddress::ltc6812(Channel::Cell6, Register::CellVoltageB, 2),
     RegisterAddress::ltc6812(Channel::Cell11, Register::CellVoltageD, 1),
@@ -331,11 +356,11 @@ impl RegisterLocator<LTC6812> for CellSelection {
     fn get_locations(&self) -> Iter<'static, RegisterAddress<LTC6812>> {
         match self {
             CellSelection::All => CELL_REGISTER_LOCATIONS.iter(),
-            CellSelection::Group1 => CELL_REGISTER_LOCATIONS[0..3].iter(),
-            CellSelection::Group2 => CELL_REGISTER_LOCATIONS[3..6].iter(),
-            CellSelection::Group3 => CELL_REGISTER_LOCATIONS[6..9].iter(),
-            CellSelection::Group4 => CELL_REGISTER_LOCATIONS[9..12].iter(),
-            CellSelection::Group5 => CELL_REGISTER_LOCATIONS[12..15].iter(),
+            CellSelection::Group1 => CELL_REGISTER_LOCATIONS_BY_PAIRS[0..3].iter(),
+            CellSelection::Group2 => CELL_REGISTER_LOCATIONS_BY_PAIRS[3..6].iter(),
+            CellSelection::Group3 => CELL_REGISTER_LOCATIONS_BY_PAIRS[6..9].iter(),
+            CellSelection::Group4 => CELL_REGISTER_LOCATIONS_BY_PAIRS[9..12].iter(),
+            CellSelection::Group5 => CELL_REGISTER_LOCATIONS_BY_PAIRS[12..15].iter(),
         }
     }
 }

--- a/src/ltc6813.rs
+++ b/src/ltc6813.rs
@@ -124,6 +124,10 @@ impl DeviceTypes for LTC6813 {
 
     const REG_CONF_A: Self::Register = Register::ConfigurationA;
     const REG_CONF_B: Option<Self::Register> = Some(Register::ConfigurationB);
+
+    const TOTAL_VOLTAGE_FACTOR: u32 = 30;
+    const INTERNAL_TEMP_GAIN: i32 = 7600;
+    const INTERNAL_TEMP_OFFSET: i16 = 276;
 }
 
 impl<B, const L: usize> LTC681X<B, NoPolling, LTC6813, L>
@@ -318,7 +322,31 @@ impl RegisterAddress<LTC6813> {
     }
 }
 
+/// Cell register locations ordered by Channel.
 const CELL_REGISTER_LOCATIONS: [RegisterAddress<LTC6813>; 18] = [
+    RegisterAddress::ltc6813(Channel::Cell1, Register::CellVoltageA, 0),
+    RegisterAddress::ltc6813(Channel::Cell2, Register::CellVoltageA, 1),
+    RegisterAddress::ltc6813(Channel::Cell3, Register::CellVoltageA, 2),
+    RegisterAddress::ltc6813(Channel::Cell4, Register::CellVoltageB, 0),
+    RegisterAddress::ltc6813(Channel::Cell5, Register::CellVoltageB, 1),
+    RegisterAddress::ltc6813(Channel::Cell6, Register::CellVoltageB, 2),
+    RegisterAddress::ltc6813(Channel::Cell7, Register::CellVoltageC, 0),
+    RegisterAddress::ltc6813(Channel::Cell8, Register::CellVoltageC, 1),
+    RegisterAddress::ltc6813(Channel::Cell9, Register::CellVoltageC, 2),
+    RegisterAddress::ltc6813(Channel::Cell10, Register::CellVoltageD, 0),
+    RegisterAddress::ltc6813(Channel::Cell11, Register::CellVoltageD, 1),
+    RegisterAddress::ltc6813(Channel::Cell12, Register::CellVoltageD, 2),
+    RegisterAddress::ltc6813(Channel::Cell13, Register::CellVoltageE, 0),
+    RegisterAddress::ltc6813(Channel::Cell14, Register::CellVoltageE, 1),
+    RegisterAddress::ltc6813(Channel::Cell15, Register::CellVoltageE, 2),
+    RegisterAddress::ltc6813(Channel::Cell16, Register::CellVoltageF, 0),
+    RegisterAddress::ltc6813(Channel::Cell17, Register::CellVoltageF, 1),
+    RegisterAddress::ltc6813(Channel::Cell18, Register::CellVoltageF, 2),
+];
+
+/// Cell register locations ordered by CellSelection. These definitions
+/// should match CELL_REGISTER_LOCATIONS.
+const CELL_REGISTER_LOCATIONS_BY_PAIRS: [RegisterAddress<LTC6813>; 18] = [
     RegisterAddress::ltc6813(Channel::Cell1, Register::CellVoltageA, 0),
     RegisterAddress::ltc6813(Channel::Cell7, Register::CellVoltageC, 0),
     RegisterAddress::ltc6813(Channel::Cell13, Register::CellVoltageE, 0),
@@ -343,12 +371,12 @@ impl RegisterLocator<LTC6813> for CellSelection {
     fn get_locations(&self) -> Iter<'static, RegisterAddress<LTC6813>> {
         match self {
             CellSelection::All => CELL_REGISTER_LOCATIONS.iter(),
-            CellSelection::Group1 => CELL_REGISTER_LOCATIONS[0..3].iter(),
-            CellSelection::Group2 => CELL_REGISTER_LOCATIONS[3..6].iter(),
-            CellSelection::Group3 => CELL_REGISTER_LOCATIONS[6..9].iter(),
-            CellSelection::Group4 => CELL_REGISTER_LOCATIONS[9..12].iter(),
-            CellSelection::Group5 => CELL_REGISTER_LOCATIONS[12..15].iter(),
-            CellSelection::Group6 => CELL_REGISTER_LOCATIONS[15..18].iter(),
+            CellSelection::Group1 => CELL_REGISTER_LOCATIONS_BY_PAIRS[0..3].iter(),
+            CellSelection::Group2 => CELL_REGISTER_LOCATIONS_BY_PAIRS[3..6].iter(),
+            CellSelection::Group3 => CELL_REGISTER_LOCATIONS_BY_PAIRS[6..9].iter(),
+            CellSelection::Group4 => CELL_REGISTER_LOCATIONS_BY_PAIRS[9..12].iter(),
+            CellSelection::Group5 => CELL_REGISTER_LOCATIONS_BY_PAIRS[12..15].iter(),
+            CellSelection::Group6 => CELL_REGISTER_LOCATIONS_BY_PAIRS[15..18].iter(),
         }
     }
 }

--- a/src/tests/device_config.rs
+++ b/src/tests/device_config.rs
@@ -105,7 +105,7 @@ fn test_ltc6813_cell_register_locations_all() {
             ltc6813::Channel::Cell16,
             ltc6813::Channel::Cell17,
             ltc6813::Channel::Cell18,
-        ]
+        ],
     );
     assert_cell_register_locations(locations.collect());
 }
@@ -151,7 +151,7 @@ fn test_ltc6812_cell_register_locations_all() {
             ltc6812::Channel::Cell13,
             ltc6812::Channel::Cell14,
             ltc6812::Channel::Cell15,
-        ]
+        ],
     );
     assert_cell_register_locations(locations.collect());
 }
@@ -192,7 +192,7 @@ fn test_ltc6811_cell_register_locations_all() {
             ltc6811::Channel::Cell10,
             ltc6811::Channel::Cell11,
             ltc6811::Channel::Cell12,
-        ]
+        ],
     );
     assert_cell_register_locations(locations.collect());
 }
@@ -257,7 +257,7 @@ fn test_ltc6810_cell_register_locations_all() {
             ltc6810::Channel::Cell4,
             ltc6810::Channel::Cell5,
             ltc6810::Channel::Cell6,
-        ]
+        ],
     );
     assert_cell_register_locations(locations.collect());
 }

--- a/src/tests/device_config.rs
+++ b/src/tests/device_config.rs
@@ -84,6 +84,29 @@ fn test_ltc6810_grouped_index() {
 #[test]
 fn test_ltc6813_cell_register_locations_all() {
     let locations = ltc6813::CellSelection::All.get_locations();
+    assert_cell_channel_mappings(
+        ltc6813::CellSelection::All.get_locations().collect(),
+        vec![
+            ltc6813::Channel::Cell1,
+            ltc6813::Channel::Cell2,
+            ltc6813::Channel::Cell3,
+            ltc6813::Channel::Cell4,
+            ltc6813::Channel::Cell5,
+            ltc6813::Channel::Cell6,
+            ltc6813::Channel::Cell7,
+            ltc6813::Channel::Cell8,
+            ltc6813::Channel::Cell9,
+            ltc6813::Channel::Cell10,
+            ltc6813::Channel::Cell11,
+            ltc6813::Channel::Cell12,
+            ltc6813::Channel::Cell13,
+            ltc6813::Channel::Cell14,
+            ltc6813::Channel::Cell15,
+            ltc6813::Channel::Cell16,
+            ltc6813::Channel::Cell17,
+            ltc6813::Channel::Cell18,
+        ]
+    );
     assert_cell_register_locations(locations.collect());
 }
 
@@ -110,6 +133,26 @@ fn test_ltc6813_cell_register_locations_groups() {
 #[test]
 fn test_ltc6812_cell_register_locations_all() {
     let locations = ltc6812::CellSelection::All.get_locations();
+    assert_cell_channel_mappings(
+        ltc6812::CellSelection::All.get_locations().collect(),
+        vec![
+            ltc6812::Channel::Cell1,
+            ltc6812::Channel::Cell2,
+            ltc6812::Channel::Cell3,
+            ltc6812::Channel::Cell4,
+            ltc6812::Channel::Cell5,
+            ltc6812::Channel::Cell6,
+            ltc6812::Channel::Cell7,
+            ltc6812::Channel::Cell8,
+            ltc6812::Channel::Cell9,
+            ltc6812::Channel::Cell10,
+            ltc6812::Channel::Cell11,
+            ltc6812::Channel::Cell12,
+            ltc6812::Channel::Cell13,
+            ltc6812::Channel::Cell14,
+            ltc6812::Channel::Cell15,
+        ]
+    );
     assert_cell_register_locations(locations.collect());
 }
 
@@ -134,6 +177,23 @@ fn test_ltc6812_cell_register_locations_groups() {
 #[test]
 fn test_ltc6811_cell_register_locations_all() {
     let locations = ltc6811::CellSelection::All.get_locations();
+    assert_cell_channel_mappings(
+        ltc6811::CellSelection::All.get_locations().collect(),
+        vec![
+            ltc6811::Channel::Cell1,
+            ltc6811::Channel::Cell2,
+            ltc6811::Channel::Cell3,
+            ltc6811::Channel::Cell4,
+            ltc6811::Channel::Cell5,
+            ltc6811::Channel::Cell6,
+            ltc6811::Channel::Cell7,
+            ltc6811::Channel::Cell8,
+            ltc6811::Channel::Cell9,
+            ltc6811::Channel::Cell10,
+            ltc6811::Channel::Cell11,
+            ltc6811::Channel::Cell12,
+        ]
+    );
     assert_cell_register_locations(locations.collect());
 }
 
@@ -158,8 +218,47 @@ fn test_ltc6811_cell_register_locations_groups() {
 }
 
 #[test]
+fn test_ltc6811_cell_selection_pairs() {
+    assert_cell_channel_mappings(
+        ltc6811::CellSelection::Pair1.get_locations().collect(),
+        vec![ltc6811::Channel::Cell1, ltc6811::Channel::Cell7],
+    );
+    assert_cell_channel_mappings(
+        ltc6811::CellSelection::Pair2.get_locations().collect(),
+        vec![ltc6811::Channel::Cell2, ltc6811::Channel::Cell8],
+    );
+    assert_cell_channel_mappings(
+        ltc6811::CellSelection::Pair3.get_locations().collect(),
+        vec![ltc6811::Channel::Cell3, ltc6811::Channel::Cell9],
+    );
+    assert_cell_channel_mappings(
+        ltc6811::CellSelection::Pair4.get_locations().collect(),
+        vec![ltc6811::Channel::Cell4, ltc6811::Channel::Cell10],
+    );
+    assert_cell_channel_mappings(
+        ltc6811::CellSelection::Pair5.get_locations().collect(),
+        vec![ltc6811::Channel::Cell5, ltc6811::Channel::Cell11],
+    );
+    assert_cell_channel_mappings(
+        ltc6811::CellSelection::Pair6.get_locations().collect(),
+        vec![ltc6811::Channel::Cell6, ltc6811::Channel::Cell12],
+    );
+}
+
+#[test]
 fn test_ltc6810_cell_register_locations_all() {
     let locations = ltc6810::CellSelection::All.get_locations();
+    assert_cell_channel_mappings(
+        ltc6810::CellSelection::All.get_locations().collect(),
+        vec![
+            ltc6810::Channel::Cell1,
+            ltc6810::Channel::Cell2,
+            ltc6810::Channel::Cell3,
+            ltc6810::Channel::Cell4,
+            ltc6810::Channel::Cell5,
+            ltc6810::Channel::Cell6,
+        ]
+    );
     assert_cell_register_locations(locations.collect());
 }
 
@@ -341,6 +440,17 @@ const CORRECT_CELL_LOCATIONS: [[usize; 3]; 18] = [
     [16, 5, 1],
     [17, 5, 2],
 ];
+
+/// Checks that the channels from the listed RegisterAddresses match expected.
+fn assert_cell_channel_mappings<T: DeviceTypes>(actual: Vec<&RegisterAddress<T>>, expected: Vec<T::Channel>)
+where
+    T::Channel: PartialEq + std::fmt::Debug,
+{
+    assert_eq!(actual.len(), expected.len());
+    for i in 0..actual.len() {
+        assert_eq!(actual[i].channel, expected[i]);
+    }
+}
 
 fn assert_cell_register_locations<T: DeviceTypes>(locations: Vec<&RegisterAddress<T>>) {
     assert_eq!(T::CELL_COUNT, locations.len());

--- a/src/tests/monitor.rs
+++ b/src/tests/monitor.rs
@@ -1684,22 +1684,6 @@ fn test_read_voltages_cell_all() {
             0xC2,
             [&[0x93, 0x61, 0xBB, 0x1E, 0xAE, 0x22, 0x9A, 0x1C]],
         )
-        // Register C
-        .expect_register_read(
-            0b0000_0000,
-            0b0000_1000,
-            0x5E,
-            0x52,
-            [&[0x61, 0x63, 0xBD, 0x1E, 0xE4, 0x22, 0x3F, 0x42]],
-        )
-        // Register E
-        .expect_register_read(
-            0b0000_0000,
-            0b0000_1001,
-            0xD5,
-            0x60,
-            [&[0xDE, 0x64, 0x8F, 0x21, 0x8A, 0x21, 0x8F, 0xDA]],
-        )
         // Register B
         .expect_register_read(
             0b0000_0000,
@@ -1708,6 +1692,14 @@ fn test_read_voltages_cell_all() {
             0x94,
             [&[0xDD, 0x66, 0x72, 0x1D, 0xA2, 0x1C, 0x11, 0x94]],
         )
+        // Register C
+        .expect_register_read(
+            0b0000_0000,
+            0b0000_1000,
+            0x5E,
+            0x52,
+            [&[0x61, 0x63, 0xBD, 0x1E, 0xE4, 0x22, 0x3F, 0x42]],
+        )
         // Register D
         .expect_register_read(
             0b0000_0000,
@@ -1715,6 +1707,14 @@ fn test_read_voltages_cell_all() {
             0xC3,
             0x4,
             [&[0x8A, 0x61, 0x61, 0x1F, 0xCF, 0x21, 0x01, 0xEE]],
+        )
+        // Register E
+        .expect_register_read(
+            0b0000_0000,
+            0b0000_1001,
+            0xD5,
+            0x60,
+            [&[0xDE, 0x64, 0x8F, 0x21, 0x8A, 0x21, 0x8F, 0xDA]],
         )
         // Register F
         .expect_register_read(


### PR DESCRIPTION
Addresses a few issues in the driver for different devices: 

1. Fix cell mappings. Currently for each device when polling for `CellSelection::ALL` the order of the returned cells is in the same order specified by `CELL_REGISTER_LOCATIONS` in each device implementation. This is not expected, this should be ordered by `Channel`. I am creating 2 separate arrays now (one for the groupings or pairs, and one `CellSelection::ALL`). It would be better if these were combined or created statically from one array.
    - Added a few more tests to check these mappings returned are correct, and I tested on a LTC6811. If wasn't able to check this on the other devices, but I noticed the same bug exists for all other device mappings.

3. Adds some device specific internal parameters related to total voltage and calculating the internal die temps.

This originated from https://github.com/atlas-aero/rt-LTC681X/issues/17.